### PR TITLE
feat: add generic uniform types to shaderMaterial

### DIFF
--- a/.storybook/stories/AccumulativeShadows.stories.ts
+++ b/.storybook/stories/AccumulativeShadows.stories.ts
@@ -19,7 +19,7 @@ let gui: GUI,
 let plm: ProgressiveLightMap, // class handles the shadow accumulation part
   gLights: THREE.Group, // group containing all the random lights
   gPlane: THREE.Mesh, // shadow catching plane
-  shadowMaterial: any // instance of SoftShadowMaterial material applied to plane to make only the shadows visible
+  shadowMaterial: InstanceType<typeof SoftShadowMaterial> // instance of SoftShadowMaterial material applied to plane to make only the shadows visible
 
 const shadowParams = {
   /** Temporal accumulates shadows over time which is more performant but has a visual regression over instant results, false  */

--- a/.storybook/stories/volumetricSpotlight.stories.ts
+++ b/.storybook/stories/volumetricSpotlight.stories.ts
@@ -36,7 +36,10 @@ export default {
 
 let spotLight: SpotLight, spotLightHelper: SpotLightHelper, gui: GUI
 
-let volumeMaterial: ShaderMaterial, volumeMesh: Mesh, depthTexture: DepthTexture, depthTarget: WebGLRenderTarget
+let volumeMaterial: InstanceType<typeof SpotLightMaterial>,
+  volumeMesh: Mesh,
+  depthTexture: DepthTexture,
+  depthTarget: WebGLRenderTarget
 
 const { renderer, scene, camera, render } = Setup()
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,35 @@ const ColorShiftMaterial = shaderMaterial(
 const mesh = new THREE.Mesh(geometry, new ColorShiftMaterial())
 ```
 
+<details>
+  <summary>TypeScript usage</summary>
+
+Uniform types can be inferred from the `uniforms` argument or passed as a generic type argument.
+
+```typescript
+  type MyMaterialProps = {
+    time: number,
+    color: THREE.Color,
+    map: THREE.Texture | null
+  }
+
+  const MyMaterial = shaderMaterial<MyMaterialProps>(
+    {
+      time: 0,
+      color: new THREE.Color(0.2, 0.0, 0.1)
+      map: null
+    },
+    vertexShader,
+    fragmentShader
+  )
+
+  const material = new MyMaterial()
+  material.time
+        // ^? (property) time: number
+```
+
+</details>
+
 #### MeshDiscardMaterial
 
 A material that discards fragments. It can be used to render nothing efficiently, but still have a mesh in the scene graph that throws shadows and can be raycast.

--- a/src/core/AccumulativeShadows.ts
+++ b/src/core/AccumulativeShadows.ts
@@ -12,19 +12,20 @@ function isGeometry(object: any): object is THREE.Mesh {
 
 type SoftShadowMaterialProps = {
   map: THREE.Texture | null
-  color?: THREE.Color
-  alphaTest?: number
-  blend?: number
+  color: THREE.Color
+  alphaTest: number
+  opacity: number
+  blend: number
 }
 
-const SoftShadowMaterial = shaderMaterial(
+const SoftShadowMaterial = shaderMaterial<SoftShadowMaterialProps>(
   {
     color: new THREE.Color(0x000000),
     blend: 2.0,
     alphaTest: 0.75,
     opacity: 0,
     map: null,
-  } as SoftShadowMaterialProps,
+  },
   `varying vec2 vUv;
    void main() {
      gl_Position = projectionMatrix * viewMatrix * modelMatrix * vec4(position, 1.);

--- a/src/core/shaderMaterial.ts
+++ b/src/core/shaderMaterial.ts
@@ -1,58 +1,61 @@
 import * as THREE from 'three'
 
-export function shaderMaterial(
-  uniforms: {
-    [name: string]:
-      | THREE.CubeTexture
-      | THREE.Texture
-      | Int32Array
-      | Float32Array
-      | THREE.Matrix4
-      | THREE.Matrix3
-      | THREE.Quaternion
-      | THREE.Vector4
-      | THREE.Vector3
-      | THREE.Vector2
-      | THREE.Color
-      | number
-      | boolean
-      | Array<any>
-      | null
-  },
+type UniformValue =
+  | THREE.CubeTexture
+  | THREE.Texture
+  | Int32Array
+  | Float32Array
+  | THREE.Matrix4
+  | THREE.Matrix3
+  | THREE.Quaternion
+  | THREE.Vector4
+  | THREE.Vector3
+  | THREE.Vector2
+  | THREE.Color
+  | number
+  | boolean
+  | Array<any>
+  | null
+
+type Uniforms = { [name: string]: UniformValue }
+
+type ShaderMaterialInstance<TUniforms extends Uniforms> = THREE.ShaderMaterial & TUniforms
+
+type ShaderMaterialParameters<TUniforms extends Uniforms> = THREE.ShaderMaterialParameters & Partial<TUniforms>
+
+type ShaderMaterial<TUniforms extends Uniforms> = (new (
+  parameters?: ShaderMaterialParameters<TUniforms>
+) => ShaderMaterialInstance<TUniforms>) & { key: string }
+
+export function shaderMaterial<TUniforms extends Uniforms>(
+  uniforms: TUniforms,
   vertexShader: string,
   fragmentShader: string,
-  onInit?: (material?: THREE.ShaderMaterial) => void
+  onInit?: (material: ShaderMaterialInstance<TUniforms>) => void
 ) {
-  const material = class extends THREE.ShaderMaterial {
-    public key: string = ''
-    constructor(parameters = {}) {
-      const entries = Object.entries(uniforms)
-      // Create unforms and shaders
-      super({
-        uniforms: entries.reduce((acc, [name, value]) => {
-          const uniform = THREE.UniformsUtils.clone({ [name]: { value } })
-          return {
-            ...acc,
-            ...uniform,
-          }
-        }, {}),
-        vertexShader,
-        fragmentShader,
-      })
-      // Create getter/setters
-      entries.forEach(([name]) =>
+  const entries = Object.entries(uniforms)
+  const uniformDefs = Object.fromEntries(entries.map(([name, value]) => [name, { value }])) as {
+    [K in keyof TUniforms]: { value: TUniforms[K] }
+  }
+
+  class Material extends THREE.ShaderMaterial {
+    static key = THREE.MathUtils.generateUUID()
+
+    constructor(parameters?: ShaderMaterialParameters<TUniforms>) {
+      super({ ...parameters, uniforms: uniformDefs, vertexShader, fragmentShader })
+
+      for (const [name] of entries) {
         Object.defineProperty(this, name, {
           get: () => this.uniforms[name].value,
           set: (v) => (this.uniforms[name].value = v),
         })
-      )
+      }
 
-      // Assign parameters, this might include uniforms
       Object.assign(this, parameters)
-      // Call onInit
-      if (onInit) onInit(this)
+
+      onInit?.(this as unknown as ShaderMaterialInstance<TUniforms>)
     }
-  } as unknown as typeof THREE.ShaderMaterial & { key: string }
-  material.key = THREE.MathUtils.generateUUID()
-  return material
+  }
+
+  return Material as ShaderMaterial<TUniforms>
 }

--- a/src/core/shaderMaterial.ts
+++ b/src/core/shaderMaterial.ts
@@ -17,31 +17,31 @@ type UniformValue =
   | Array<any>
   | null
 
-type Uniforms = { [name: string]: UniformValue }
+type UniformProps = { [name: string]: UniformValue }
 
-type ShaderMaterialInstance<TUniforms extends Uniforms> = THREE.ShaderMaterial & TUniforms
+type ShaderMaterialInstance<TProps extends UniformProps> = THREE.ShaderMaterial & TProps
 
-type ShaderMaterialParameters<TUniforms extends Uniforms> = THREE.ShaderMaterialParameters & Partial<TUniforms>
+type ShaderMaterialParameters<TProps extends UniformProps> = THREE.ShaderMaterialParameters & Partial<TProps>
 
-type ShaderMaterial<TUniforms extends Uniforms> = (new (
-  parameters?: ShaderMaterialParameters<TUniforms>
-) => ShaderMaterialInstance<TUniforms>) & { key: string }
+type ShaderMaterial<TProps extends UniformProps> = (new (
+  parameters?: ShaderMaterialParameters<TProps>
+) => ShaderMaterialInstance<TProps>) & { key: string }
 
-export function shaderMaterial<TUniforms extends Uniforms>(
-  uniforms: TUniforms,
+export function shaderMaterial<TProps extends UniformProps>(
+  uniforms: TProps,
   vertexShader: string,
   fragmentShader: string,
-  onInit?: (material: ShaderMaterialInstance<TUniforms>) => void
+  onInit?: (material: ShaderMaterialInstance<TProps>) => void
 ) {
   const entries = Object.entries(uniforms)
   const uniformDefs = Object.fromEntries(entries.map(([name, value]) => [name, { value }])) as {
-    [K in keyof TUniforms]: { value: TUniforms[K] }
+    [K in keyof TProps]: { value: TProps[K] }
   }
 
   class Material extends THREE.ShaderMaterial {
     static key = THREE.MathUtils.generateUUID()
 
-    constructor(parameters?: ShaderMaterialParameters<TUniforms>) {
+    constructor(parameters?: ShaderMaterialParameters<TProps>) {
       super({ ...parameters, uniforms: uniformDefs, vertexShader, fragmentShader })
 
       for (const [name] of entries) {
@@ -53,9 +53,9 @@ export function shaderMaterial<TUniforms extends Uniforms>(
 
       Object.assign(this, parameters)
 
-      onInit?.(this as unknown as ShaderMaterialInstance<TUniforms>)
+      onInit?.(this as unknown as ShaderMaterialInstance<TProps>)
     }
   }
 
-  return Material as ShaderMaterial<TUniforms>
+  return Material as ShaderMaterial<TProps>
 }

--- a/src/materials/SpotLightMaterial.ts
+++ b/src/materials/SpotLightMaterial.ts
@@ -1,7 +1,21 @@
-import { Color, Vector2, Vector3 } from 'three'
+import { Color, Vector2, Vector3, type Texture } from 'three'
 import { shaderMaterial } from '../core/shaderMaterial'
 
-export const SpotLightMaterial = shaderMaterial(
+type SpotLightMaterialProps = {
+  depth: Texture | null
+  opacity: number
+  attenuation: number
+  anglePower: number
+  spotPosition: Vector3
+  lightColor: Color
+  cameraNear: number
+  cameraFar: number
+  resolution: Vector2
+  transparent: boolean
+  depthWrite: boolean
+}
+
+export const SpotLightMaterial = shaderMaterial<SpotLightMaterialProps>(
   {
     depth: null,
     opacity: 1,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Resolves #23 

### What

I added a generic type parameter to `shaderMaterial()` that can be inferred from its `uniforms` argument or provided explicitly. I also updated the Storybook examples to use explicit uniform types. This resolves some TS errors in the examples. Lastly I added a "TypeScript usage" dropdown to the README showing how to provide uniform types.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->

