### PR TITLE
fix: compat for r154 shader chunk renames

### DIFF
--- a/src/core/Grid.ts
+++ b/src/core/Grid.ts
@@ -105,7 +105,7 @@ const GridMaterial = shaderMaterial<GridProps & any>(
         if (gl_FragColor.a <= 0.0) discard;
   
         #include <tonemapping_fragment>
-        #include <encodings_fragment>
+        #include <${parseInt(THREE.REVISION.replace(/\D+/g, '')) >= 154 ? 'colorspace_fragment' : 'encodings_fragment'}>
       }
     `
 )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Threejs has been renamed `encodings_fragment` to `colorspace_fragment` since r154.

This will fix the warning:

> `THREE.WebGLRenderer: Shader chunk "encodings_fragment" has been deprecated. Use "colorspace_fragment" instead.`

### What

<!-- what have you done, if its a bug, whats your solution? -->

Check the version of three.js and choose the right shader chunks.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [x]  Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
