### PR TITLE
fix: Outline use BufferGeometryUtils

### DIFF
--- a/src/core/Outlines.ts
+++ b/src/core/Outlines.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import { toCreasedNormals } from 'three-stdlib'
+import { toCreasedNormals } from 'three/examples/jsm/utils/BufferGeometryUtils'
 import { shaderMaterial } from './shaderMaterial'
 
 export type OutlinesProps = {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
deps error when three-stdlib was not installed
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
Use toCreasedNormals from BufferGeometryUtils instead
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
