### PR TITLE
feat: expose Caustics materials and types as public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,33 @@ export type CausticsType = {
 }
 ```
 
+##### Integrating with frontend frameworks
+
+If you are using a frontend framework, the construction of `Caustics` effect by calling `Caustics()` _might not_ be enough due to how frameworks handle the component life-cycle, changes when props change, and content projection / rendering children.
+
+To accommodate this use-case, `@pmndrs/vanilla` exports the following symbols to help you integrate the caustics effect with your frontend framework:
+
+- `CausticsProjectionMaterial`: A material that projects the caustics onto the catcher plane.
+- `CausticsMaterial`: A material that renders the caustics.
+- `createCausticsUpdate`: A function that accepts an `updateParameters` function/getter and creates an `update` function for the caustics effect. This function should be called in the animation loop implementation of your framework, and `updateParameters` should return the latest value of the parameters based on your framework's state management.
+
+```ts
+export function createCausticsUpdate(
+  updateParameters: () => {
+    params: Omit<CausticsProps, 'color'>
+    scene: THREE.Scene
+    group: THREE.Group
+    camera: THREE.OrthographicCamera
+    plane: THREE.Mesh<PlaneGeometry, InstanceType<typeof CausticsProjectionMaterial>>
+    normalTarget: THREE.WebGLRenderTarget
+    normalTargetB: THREE.WebGLRenderTarget
+    causticsTarget: THREE.WebGLRenderTarget
+    causticsTargetB: THREE.WebGLRenderTarget
+    helper?: THREE.CameraHelper | null
+  }
+): (gl: THREE.WebGLRenderer) => void
+```
+
 #### Cloud
 
 [![storybook](https://img.shields.io/badge/-storybook-%23ff69b4)](https://pmndrs.github.io/drei-vanilla/?path=/story/staging-clouds--cloud-story)


### PR DESCRIPTION
This PR exposes Caustics materials and types as public API. I didn't document the public API for the change because the current state of the README doesn't state what's exposed as public API. Please let me know if you want this documented in the README.

### Why

`Caustics` export only the `Caustics` function to create the entire Caustics construct and the `update` function. This makes it trickier for declarative framework integrations that allow for:
- Updating parameters without recreating `Caustics` by using their templating language (jsx, html etc...)
- Content Projection / Rendering Children where content/children is supposed to go (as children of the exposed `scene`)

### What

- Expose the materials and their types as public API
- Add `createCausticsUpdate` function to create an `update` function that the consumers can call in their animation loop implementations.

### Checklist

- [x] Documentation updated
- [x] Ready to be merged

