### PR TITLE
fix: integrate fog support into SpotLightMaterial shader

### DIFF
--- a/src/materials/SpotLightMaterial.ts
+++ b/src/materials/SpotLightMaterial.ts
@@ -1,4 +1,4 @@
-import { Color, Vector2, Vector3, type Texture } from 'three'
+import { Color, Vector2, Vector3, type Texture, UniformsLib, UniformsUtils } from 'three'
 import { shaderMaterial } from '../core/shaderMaterial'
 import { version } from '../helpers/constants'
 
@@ -37,10 +37,15 @@ export const SpotLightMaterial = shaderMaterial<SpotLightMaterialProps>(
   uniform vec3 spotPosition;
   uniform float attenuation;
 
+  #include <fog_pars_vertex>
   #include <common>
   #include <logdepthbuf_pars_vertex>
-
+  
   void main() {
+  	#include <begin_vertex>
+    #include <project_vertex>
+    #include <fog_vertex>
+
     // compute intensity
     vNormal = normalize(normalMatrix * normal);
     vec4 worldPosition = modelMatrix * vec4(position, 1);
@@ -66,6 +71,7 @@ export const SpotLightMaterial = shaderMaterial<SpotLightMaterialProps>(
   uniform float cameraFar;
   uniform float opacity;
 
+  #include <fog_pars_fragment>
   #include <packing>
   #include <logdepthbuf_pars_fragment>
 
@@ -100,5 +106,9 @@ export const SpotLightMaterial = shaderMaterial<SpotLightMaterialProps>(
 
     #include <tonemapping_fragment>
     #include <${version >= 154 ? 'colorspace_fragment' : 'encodings_fragment'}>
-  }`
+    #include <fog_fragment>
+  }`,
+  (material) => {
+    Object.assign(material.uniforms, UniformsUtils.merge([UniformsLib['fog']]))
+  }
 )


### PR DESCRIPTION


### Why

spot light volume cone meshes visible through fog

### What

add fog related shader code to support scene.fog

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
