### PR TITLE
Support shadow.intensity parameter

### DIFF
--- a/.storybook/stories/PCSS.stories.ts
+++ b/.storybook/stories/PCSS.stories.ts
@@ -32,6 +32,7 @@ export const PcssStory = async () => {
     size: 25,
     focus: 0,
     samples: 10,
+    intensity: 1,
   }
 
   const folder = gui.addFolder('Settings')
@@ -42,6 +43,7 @@ export const PcssStory = async () => {
   folder.add(args, 'size', 1, 100, 1)
   folder.add(args, 'focus', 0, 2, 0.1)
   folder.add(args, 'samples', 1, 20, 1)
+  folder.add(args, 'intensity', 0, 1, 0.1)
 
   const { renderer, scene, camera, render } = Setup()
 
@@ -62,6 +64,7 @@ export const PcssStory = async () => {
   light.shadow.mapSize.width = 1024
   light.shadow.mapSize.height = 1024
   light.shadow.camera.far = 20
+  light.shadow.intensity = 1
 
   scene.add(light)
 
@@ -113,8 +116,10 @@ export const PcssStory = async () => {
     }
   })
 
-  const updatePCSS = (args: { enabled: boolean; size: number; focus: number; samples: number }) => {
-    const { enabled, size, focus, samples } = args
+  const updatePCSS = (args: { enabled: boolean; size: number; focus: number; samples: number; intensity: number }) => {
+    const { enabled, size, focus, samples, intensity } = args
+
+    light.shadow.intensity = intensity
 
     if (reset) {
       reset(renderer, scene, camera)

--- a/src/core/pcss.ts
+++ b/src/core/pcss.ts
@@ -151,7 +151,7 @@ export const pcss = ({ focus = 0, size = 25, samples = 10 }: SoftShadowsProps = 
     )
     .replace(
       '#if defined( SHADOWMAP_TYPE_PCF )',
-      '\nreturn PCSS(shadowMap, shadowCoord);\n#if defined( SHADOWMAP_TYPE_PCF )'
+      '\nreturn mix( 1.0, PCSS(shadowMap, shadowCoord), shadowIntensity );\n#if defined( SHADOWMAP_TYPE_PCF )'
     )
   return (gl: THREE.Renderer, scene: THREE.Scene, camera: THREE.Camera) => {
     THREE.ShaderChunk.shadowmap_pars_fragment = original


### PR DESCRIPTION
### Why

PCSS lacked shadow intensity support

### What

Added support for shadowIntensity parameter in the shadow pars fragment to allow the PCSS to be affected by the intensity parameter.
No config needed, just intended behaviour from my side.

### Checklist

- [ ] Documentation updated (Should not be needed but i could be wrong)
- [x] Ready to be merged

This limits support to r166 upwards, but we should be good as it's already required