### PR TITLE
Caustics set FBO type to HalfFloatType when its extension is not supported

### DIFF
--- a/src/core/Caustics.ts
+++ b/src/core/Caustics.ts
@@ -258,7 +258,12 @@ const NORMALPROPS = {
   type: THREE.UnsignedByteType,
 }
 
-const CAUSTICPROPS = {
+const CAUSTICPROPS: {
+  minFilter: THREE.MinificationTextureFilter
+  magFilter: THREE.MagnificationTextureFilter
+  type: THREE.TextureDataType
+  generateMipmaps: boolean
+} = {
   minFilter: THREE.LinearMipmapLinearFilter,
   magFilter: THREE.LinearFilter,
   type: THREE.FloatType,
@@ -525,6 +530,12 @@ export const Caustics = (
   const res = params.resolution
   const normalTarget = useFBO(res, res, NORMALPROPS)
   const normalTargetB = useFBO(res, res, NORMALPROPS)
+
+  if (!renderer.extensions.get('OES_texture_float_linear')) {
+    console.warn('Caustics: OES_texture_float_linear extension is not supported, using HalfFloatType instead.')
+    CAUSTICPROPS.type = THREE.HalfFloatType
+  }
+
   const causticsTarget = useFBO(res, res, CAUSTICPROPS)
   const causticsTargetB = useFBO(res, res, CAUSTICPROPS)
 


### PR DESCRIPTION

### Why
The FBOs in Caustics currently use `FloatType` by default, which causes issues on devices that do not support the `OES_texture_float_linear` WebGL extension. While this does not crash the renderer, caustics are not rendered and warnings appear in the console.



### What
This PR updates the code to check if the extension is supported using the `renderer.extensions.get('xxxx')` method. If not supported, it falls back to `HalfFloatType`.




### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
