### PR TITLE
Implement cube camera

### DIFF
--- a/.storybook/stories/CubeCamera.stories.ts
+++ b/.storybook/stories/CubeCamera.stories.ts
@@ -1,0 +1,84 @@
+import * as THREE from 'three'
+import { Setup } from '../Setup'
+import { Meta } from '@storybook/html'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import GUI from 'lil-gui'
+
+import { CubeCamera, CubeCameraType } from '../../src/core/CubeCamera'
+
+export default {
+  title: 'Camera/CubeCamera',
+} as Meta
+
+let gui: GUI
+
+export const CubeCameraStory = async () => {
+  const { renderer, scene, camera, render } = Setup()
+  gui = new GUI({ title: CubeCameraStory.storyName })
+
+  camera.position.set(0, 10, 40)
+
+  const controls = new OrbitControls(camera, renderer.domElement)
+  controls.update()
+
+  scene.fog = new THREE.Fog('#f0f0f0', 100, 200)
+  scene.background = new THREE.Color('#f0f0f0')
+
+  const ambientLight = new THREE.AmbientLight(0xffffff, 0.5 * Math.PI)
+  scene.add(ambientLight)
+
+  const dirLight = new THREE.DirectionalLight(0xffffff, 2)
+  dirLight.position.set(10, 10, 10)
+  scene.add(dirLight)
+
+  const box = new THREE.Mesh(new THREE.BoxGeometry(5, 5, 5), new THREE.MeshStandardMaterial({ color: 'hotpink' }))
+  box.position.y = 2.5
+  scene.add(box)
+
+  scene.add(new THREE.GridHelper(100, 10))
+
+  const sphere1 = createReflectiveSphere(renderer, scene, { position: [-10, 10, 0], frames: Infinity })
+  const sphere2 = createReflectiveSphere(renderer, scene, { position: [10, 9, 0], frames: Infinity })
+
+  scene.add(sphere1.cubeCamera.group)
+  scene.add(sphere2.cubeCamera.group)
+
+  const folder = gui.addFolder('Sphere 1')
+  folder.add(sphere1.mesh.position, 'x', -20, 20)
+  folder.add(sphere1.mesh.position, 'y', 0, 20)
+  folder.add(sphere1.mesh.position, 'z', -20, 20)
+
+  let elapsed = 0
+  render((time) => {
+    const dt = time * 0.001
+    elapsed = dt
+    controls.update()
+
+    sphere1.mesh.position.y = Math.sin(elapsed) * 5 + 10
+    sphere2.mesh.position.y = Math.sin(2000 + elapsed) * 5 + 9
+
+    sphere1.cubeCamera.update()
+    sphere2.cubeCamera.update()
+  })
+}
+
+function createReflectiveSphere(
+  renderer: THREE.WebGLRenderer,
+  scene: THREE.Scene,
+  opts: { position: [number, number, number]; frames?: number }
+) {
+  const cubeCamera = CubeCamera(renderer, scene, { resolution: 256, frames: opts.frames })
+
+  const mesh = new THREE.Mesh(
+    new THREE.SphereGeometry(5, 64, 64),
+    new THREE.MeshStandardMaterial({ roughness: 0, metalness: 1, envMap: cubeCamera.texture })
+  )
+  mesh.position.set(...opts.position)
+  cubeCamera.group.add(mesh)
+
+  cubeCamera.camera.position.copy(mesh.position)
+
+  return { cubeCamera, mesh }
+}
+
+CubeCameraStory.storyName = 'Default'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ import { pcss, ... } from '@pmndrs/vanilla'
 <table>
   <tr>
     <td valign="top">
-      <ul>                
+      <ul>
+        <li><a href="#camera">Camera</a></li>
+        <ul>
+          <li><a href="#cubecamera">CubeCamera</a></li>
+        </ul>
         <li><a href="#shaders">Shaders</a></li>
         <ul>
           <li><a href="#pcss">pcss</a></li>
@@ -82,6 +86,63 @@ import { pcss, ... } from '@pmndrs/vanilla'
 
   </tr>
 </table>
+
+# Camera
+
+#### CubeCamera
+
+[![storybook](https://img.shields.io/badge/-storybook-%23ff69b4)](https://pmndrs.github.io/drei-vanilla/?path=/story/camera-cubecamera--cube-camera-story)
+
+[drei counterpart](https://drei.docs.pmnd.rs/camera/cube-camera)
+
+A helper that renders the scene into a cube render target and provides the resulting texture as an environment map. Children added to the group are automatically hidden during cube capture to avoid feedback loops.
+
+```ts
+export type CubeCameraProps = {
+  /** Resolution of the FBO, default: 256 */
+  resolution?: number
+  /** Camera near, default: 0.1 */
+  near?: number
+  /** Camera far, default: 1000 */
+  far?: number
+  /** How many frames it will render, set it to Infinity for runtime, default: Infinity */
+  frames?: number
+  /** Custom environment map that is temporarily set as the scene's background */
+  envMap?: THREE.Texture
+  /** Custom fog that is temporarily set as the scene's fog */
+  fog?: THREE.Fog | THREE.FogExp2
+}
+```
+
+Usage
+
+```js
+const cubeCamera = CubeCamera(renderer, scene, { resolution: 256, frames: 1 })
+scene.add(cubeCamera.group)
+
+// Add meshes that need the envMap (hidden during capture)
+const mesh = new THREE.Mesh(
+  geometry,
+  new THREE.MeshStandardMaterial({ roughness: 0, metalness: 1, envMap: cubeCamera.texture })
+)
+cubeCamera.group.add(mesh)
+
+// Call in animate loop
+cubeCamera.update()
+```
+
+CubeCamera function returns the following
+
+```js
+export type CubeCameraType = {
+  group: THREE.Group // group whose children are hidden during capture
+  camera: THREE.CubeCamera // the cube camera instance
+  fbo: THREE.WebGLCubeRenderTarget // the render target
+  texture: THREE.CubeTexture // the resulting cube texture, use as envMap
+  params: CubeCameraProps // mutable params
+  update: () => void // call in animate loop
+}
+```
 
 # Shaders
 

--- a/src/core/CubeCamera.ts
+++ b/src/core/CubeCamera.ts
@@ -1,0 +1,67 @@
+import * as THREE from 'three'
+
+export type CubeCameraProps = {
+  /** Resolution of the FBO, default: 256 */
+  resolution?: number
+  /** Camera near, default: 0.1 */
+  near?: number
+  /** Camera far, default: 1000 */
+  far?: number
+  /** How many frames it will render, set it to Infinity for runtime, default: Infinity */
+  frames?: number
+  /** Custom environment map that is temporarily set as the scene's background */
+  envMap?: THREE.Texture
+  /** Custom fog that is temporarily set as the scene's fog */
+  fog?: THREE.Fog | THREE.FogExp2
+}
+
+export type CubeCameraType = {
+  /** Group whose children are hidden during cube capture, add your meshes here */
+  group: THREE.Group
+  /** The cube camera instance (added to group automatically) */
+  camera: THREE.CubeCamera
+  /** The render target */
+  fbo: THREE.WebGLCubeRenderTarget
+  /** The resulting cube texture, use as envMap */
+  texture: THREE.CubeTexture
+  /** Mutable params */
+  params: CubeCameraProps
+  /** Call in your render loop */
+  update: () => void
+}
+
+export const CubeCamera = (
+  renderer: THREE.WebGLRenderer,
+  scene: THREE.Scene,
+  { resolution = 256, near = 0.1, far = 1000, frames = Infinity, envMap, fog }: CubeCameraProps = {}
+): CubeCameraType => {
+  const params: CubeCameraProps = { resolution, near, far, frames, envMap, fog }
+
+  const fbo = new THREE.WebGLCubeRenderTarget(resolution)
+  fbo.texture.type = THREE.HalfFloatType
+
+  const camera = new THREE.CubeCamera(near, far, fbo)
+
+  // hidden during cube filming
+  const group = new THREE.Group()
+  group.add(camera)
+
+  let count = 0
+
+  function update() {
+    if (frames === Infinity || count < frames) {
+      group.visible = false
+      const originalFog = scene.fog
+      const originalBackground = scene.background
+      scene.background = params.envMap || originalBackground
+      scene.fog = params.fog || originalFog
+      camera.update(renderer, scene)
+      scene.fog = originalFog
+      scene.background = originalBackground
+      group.visible = true
+      count++
+    }
+  }
+
+  return { group, camera, fbo, texture: fbo.texture, params, update }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,6 +3,9 @@ export * from './pcss'
 export * from './Caustics'
 export * from './shaderMaterial'
 
+// Camera
+export * from './CubeCamera'
+
 // Staging/Prototyping
 export * from './AccumulativeShadows'
 export * from './Cloud'


### PR DESCRIPTION
### Why

No vanilla equivalent of drei's `<CubeCamera>` — users must manually wire up render targets, hide/show, and frame counting. This is groundwork towards porting `MeshRefractionMaterial` and its demos from drei.

### What

Adds `CubeCamera()` factory + storybook demo. Follows the `Caustics()` pattern.

### Checklist

- [x] Documentation updated
- [x] Ready to be merged
